### PR TITLE
Ensure that "Norway" is interpreted as string

### DIFF
--- a/app/src/main/res/raw/country_codes.yml
+++ b/app/src/main/res/raw/country_codes.yml
@@ -165,7 +165,7 @@ NF: [en,pih]
 NG: en
 NI: es
 NL: nl
-NO: [nb,nn,no,se]
+"NO": [nb,nn,no,se]
 NP: ne
 NR: [na,en]
 NU: [niu,en]


### PR DESCRIPTION
In yaml, no is parsed as a boolean type.

You have to wrap "NO" in quotes to get the expected result.
NI: Nicaragua
NL: Netherlands
NO: Norway # 💣!

See: https://noyaml.com/